### PR TITLE
adding support for turning off timestamps

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -21,9 +21,8 @@ import (
 	"strings"
 	"time"
 
-	lol "github.com/kris-nova/lolgopher"
-
 	"github.com/fatih/color"
+	lol "github.com/kris-nova/lolgopher"
 )
 
 type Logger func(format string, a ...interface{})
@@ -44,6 +43,7 @@ var (
 	FabulousWriter     = lol.NewLolWriter()
 	FabulousTrueWriter = lol.NewTruecolorLolWriter()
 	TestMode           = false
+	Timestamps         = true
 )
 
 func Always(format string, a ...interface{}) {
@@ -132,7 +132,6 @@ func Debug(format string, a ...interface{}) {
 
 		fmt.Fprintf(w, s)
 
-
 	}
 }
 
@@ -165,15 +164,29 @@ func extractLoggerArgs(format string, a ...interface{}) ([]interface{}, io.Write
 		}
 	}
 
-
 	return a, w
 }
 
 func label(format, label string) string {
+	if Timestamps {
+		return labelWithTime(format, label)
+	} else {
+		return labelWithoutTime(format, label)
+	}
+}
+
+func labelWithTime(format, label string) string {
 	t := time.Now()
 	rfct := t.Format(time.RFC3339)
 	if !strings.Contains(format, "\n") {
 		format = fmt.Sprintf("%s%s", format, "\n")
 	}
 	return fmt.Sprintf("%s [%s]  %s", rfct, label, format)
+}
+
+func labelWithoutTime(format, label string) string {
+	if !strings.Contains(format, "\n") {
+		format = fmt.Sprintf("%s%s", format, "\n")
+	}
+	return fmt.Sprintf("[%s]  %s", label, format)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -18,13 +18,13 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 )
 
 const (
-	format    = "%v, %v, %v, all eyes on me!"
-	formatExp = `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.* \[%s\]  \d, \d, \d, all eyes on me!`
+	format          = "%v, %v, %v, all eyes on me!"
+	formatExp       = `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.* \[%s\]  \d, \d, \d, all eyes on me!`
+	formatWOTimeExp = `\[%s\]  \d, \d, \d, all eyes on me!`
 )
 
 var (
@@ -35,20 +35,6 @@ func TestMain(m *testing.M) {
 	TestMode = true
 
 	m.Run()
-}
-
-func ExampleTestLog() {
-	Log(format, a...)
-	// Output: 1, 2, 3, all eyes on me!
-}
-
-func TestLog(t *testing.T) {
-	e := fmt.Sprintf(format, a...)
-	g := captureLoggerOutput(Log, format, a)
-
-	if strings.Compare(e, g) != 0 {
-		t.Fatalf("Log should produce '%v' but produces: %v", e, g)
-	}
 }
 
 func TestAlways(t *testing.T) {
@@ -136,6 +122,20 @@ func TestWarning(t *testing.T) {
 
 	if !e.MatchString(g) {
 		t.Fatalf("Info should produce a pattern '%v' but produces: %v", e.String(), g)
+	}
+}
+
+func TestWithoutTimestamps(t *testing.T) {
+	Timestamps = false
+	e, err := regexp.Compile(fmt.Sprintf(formatWOTimeExp, AlwaysLabel))
+	g := captureLoggerOutput(Always, format, a)
+
+	if err != nil {
+		t.Fatalf("Failed to compile regexp '%v': %v", e.String(), err)
+	}
+
+	if !e.MatchString(g) {
+		t.Fatalf("Always should produce a pattern '%v' but produces: %v", e.String(), g)
 	}
 }
 


### PR DESCRIPTION
Closes #1 

Also fixes the tests since `Log()` was removed.

Signed-off-by: Christopher Hein <me@christopherhein.com>