### PR TITLE
Replace Fprintf by just Fprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/kris-nova/logger
+
+go 1.14
+
+require (
+	github.com/fatih/color v1.9.0
+	github.com/kris-nova/lolgopher v0.0.0-20180921204813-313b3abb0d9b
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/kris-nova/lolgopher v0.0.0-20180921204813-313b3abb0d9b h1:xYEM2oBUhBEhQjrV+KJ9lEWDWYZoNVZUaBF++Wyljq4=
+github.com/kris-nova/lolgopher v0.0.0-20180921204813-313b3abb0d9b/go.mod h1:V0HF/ZBlN86HqewcDC/cVxMmYDiRukWjSrgKLUAn9Js=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/logger.go
+++ b/logger.go
@@ -59,7 +59,7 @@ func Always(format string, a ...interface{}) {
 		}
 	}
 
-	fmt.Fprintf(w, s)
+	fmt.Fprint(w, s)
 }
 
 func Critical(format string, a ...interface{}) {
@@ -76,7 +76,7 @@ func Critical(format string, a ...interface{}) {
 			}
 		}
 
-		fmt.Fprintf(w, s)
+		fmt.Fprint(w, s)
 	}
 }
 
@@ -94,7 +94,7 @@ func Info(format string, a ...interface{}) {
 			}
 		}
 
-		fmt.Fprintf(w, s)
+		fmt.Fprint(w, s)
 	}
 }
 
@@ -112,7 +112,7 @@ func Success(format string, a ...interface{}) {
 			}
 		}
 
-		fmt.Fprintf(w, s)
+		fmt.Fprint(w, s)
 	}
 }
 
@@ -130,8 +130,7 @@ func Debug(format string, a ...interface{}) {
 			}
 		}
 
-		fmt.Fprintf(w, s)
-
+		fmt.Fprint(w, s)
 	}
 }
 
@@ -149,7 +148,7 @@ func Warning(format string, a ...interface{}) {
 			}
 		}
 
-		fmt.Fprintf(w, s)
+		fmt.Fprint(w, s)
 	}
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/weaveworks/eksctl/issues/836

## Approach
This issue happens if the log message is have special character %. As we already performed formating in https://github.com/kris-nova/logger/blob/master/logger.go#L51, we don't need to use Fprintf again.

## Note
I also take this chance to add go.mod file for this library as well