### PR TITLE
Allow the `Line` formatter to be overridden

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -102,7 +102,7 @@ func LineBytes(prefix, format string, a ...interface{}) []byte {
 }
 
 // Line will format a log line, and return a string
-func Line(prefix, format string, a ...interface{}) string {
+var Line = func(prefix, format string, a ...interface{}) string {
 	if !strings.Contains(format, "\n") {
 		format = fmt.Sprintf("%s%s", format, "\n")
 	}


### PR DESCRIPTION
Hi, one of the `eksctl` maintainers here :slightly_smiling_face: . We forked `kris-nova/logger` a few days before the `0.2.0` update in order to get #4. We need the change in this PR to [get parity with `0.1.0` + `Color = true` and use `"github.com/fatih/color"` to set the color instead of prepending with the log level.](https://github.com/michaelbeaumont/eksctl/blob/a1564e4cf825be9fd8936794e230d3b5c2d267ea/cmd/eksctl/main.go#L78-L79)
WDYT?